### PR TITLE
Fixes to Windows platform build

### DIFF
--- a/libgpg-error-sys/Cargo.toml
+++ b/libgpg-error-sys/Cargo.toml
@@ -26,4 +26,4 @@ path = "lib.rs"
 libc = "0.2"
 
 [target.'cfg(windows)'.build-dependencies]
-winreg = "0.7"
+winreg = "0.10.1"


### PR DESCRIPTION
1. Fixes an issue with winreg-rs where registry strings are NULL terminated which is causing a panic on windows with current rust compiler [issue](https://github.com/gentoo90/winreg-rs/issues/34)
2. Added detection of 32bit GPG libraries installed on 64bit Windows. If detected, outputting a message that it should be build using a 32bit target.